### PR TITLE
Add resetPage method and 'extra' option

### DIFF
--- a/src/jquery.infiniteScroll.js
+++ b/src/jquery.infiniteScroll.js
@@ -17,14 +17,23 @@
         var scrollTriggered = 0;
 
         $this.find(opts.itemSelector + ':last').addClass('last-scroll-row');
+        var rowData = $('.last-scroll-row').data(); // cache for first "last row"
 
         $(window).on('scroll', function() {
             var row = $('.last-scroll-row');
             if (row.length && !scrollTriggered && isScrolledIntoView(row)) {
                 scrollTriggered = 1;
+                opts.extra = $.extend(opts.extra, rowData);
                 triggerDataLoad();
             }
         });
+        
+        $.fn.infiniteScroll.resetPage = function(){
+            currentScrollPage = 1;
+        }
+        $.fn.infiniteScroll.setExtra = function(data){
+            opts.extra = $.extend(opts.extra, data);
+        }
 
         function isScrolledIntoView(elem) {
             var docViewTop = $(window).scrollTop();
@@ -52,7 +61,8 @@
             if (jQuery.isFunction(opts.onDataLoading)) {
                 opts.onDataLoading(currentScrollPage);
             }
-            $.get(opts.dataPath + '?page=' + currentScrollPage)
+            params = $.extend(opts.extra, {page: currentScrollPage});
+            $.get(opts.dataPath, params)
                 .always(onDataLoaded)
                 .fail(function() {
                     if (jQuery.isFunction(opts.onDataError)) {


### PR DESCRIPTION
I'm using this in production where I have a sort button that changes the sorting of the list. Therefore I needed a resetPage method and a method that attaches some information to the request for a new page (e.g. which sort or filter is applied).

Usage:

```
$("#items").infiniteScroll.resetPage();
$("#items").infiniteScroll.setExtra({sort: 'popularity'});
```

Can also be set at the beginning and the data will be sent along:

```
$("#items").infiniteScroll({
    itemSelector: '.widget',
    extra: {some data here},
    ...
});
```

Also I added a cache for data in the last row that is encountered first. So one can do `<div class="widget" data-id="123">` for an item and the infinite scroll will attach `id=123` to every request and the backend can better figure out pagination stuff if needed.
